### PR TITLE
cast WHIPLASH_RATE_LIMIT to an integer

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/lib/whiplash/app/api_config.rb
+++ b/lib/whiplash/app/api_config.rb
@@ -19,7 +19,7 @@ module Whiplash
       end
 
       def rate_limit
-        ENV['WHIPLASH_RATE_LIMIT'] || 25
+        (ENV['WHIPLASH_RATE_LIMIT'] || 25).to_i
       end
 
     end


### PR DESCRIPTION
need to cast the result of `rate_limit` to an Int, otherwise if you set WHIPLASH_RATE_LIMIT and pull it from the ENV, it'll come in as a string, which Sidekiq limiter doesnt like:

referenced from https://github.com/whiplashmerch/whiplash-app/blob/master/lib/whiplash/app/connections.rb#L27