### PR TITLE
Feature backwards compatible v2.1 requests

### DIFF
--- a/lib/whiplash/app.rb
+++ b/lib/whiplash/app.rb
@@ -23,8 +23,8 @@ module Whiplash
         OAuth2::Client.new(ENV["WHIPLASH_CLIENT_ID"], ENV["WHIPLASH_CLIENT_SECRET"], site: api_url)
       end
 
-      def connection
-        out = Faraday.new [api_url, "api/v2"].join("/") do |conn|
+      def connection(version = "api/v2")
+        out = Faraday.new [api_url, version].join("/") do |conn|
           conn.request :oauth2, token, token_type: "bearer"
           conn.request :json
           conn.response :json, :content_type => /\bjson$/

--- a/lib/whiplash/app/connections.rb
+++ b/lib/whiplash/app/connections.rb
@@ -9,7 +9,7 @@ module Whiplash
           endpoint = options[:endpoint]
         end
 
-        if options.dig(:options, :version)
+        if options[:options] && options[:options][:version]
           version = options.dig(:options, :version)
         else
           version = "api/v2"

--- a/lib/whiplash/app/connections.rb
+++ b/lib/whiplash/app/connections.rb
@@ -8,38 +8,53 @@ module Whiplash
         else
           endpoint = options[:endpoint]
         end
-        connection.send(options[:method],
-                        endpoint,
-                        options[:params],
-                        sanitize_headers(options[:headers]))
+
+        if options.dig(:options, :version)
+          version = options.dig(:options, :version)
+        else
+          version = "api/v2"
+        end
+
+        connection(version).send(options[:method],
+                                 endpoint,
+                                 options[:params],
+                                 sanitize_headers(options[:headers]))
       end
 
-      def delete(endpoint, params = {}, headers = nil)
+      def delete(endpoint, params = {}, headers = nil, options = {})
         app_request(method: :delete,
                     endpoint: endpoint,
                     params: params,
-                    headers: headers)
+                    headers: headers,
+                    options: options
+                   )
       end
 
-      def get(endpoint, params = {}, headers = nil)
+      def get(endpoint, params = {}, headers = nil, options = {})
         app_request(method: :get,
                     endpoint: endpoint,
                     params: params,
-                    headers: headers)
+                    headers: headers,
+                    options: options
+                   )
       end
 
-      def post(endpoint, params = {}, headers = nil)
+      def post(endpoint, params = {}, headers = nil, options = {})
         app_request(method: :post,
                     endpoint: endpoint,
                     params: params,
-                    headers: headers)
+                    headers: headers,
+                    options: options
+                   )
       end
 
-      def put(endpoint, params = {}, headers = nil)
+      def put(endpoint, params = {}, headers = nil, options = {})
         app_request(method: :put,
                     endpoint: endpoint,
                     params: params,
-                    headers: headers)
+                    headers: headers,
+                    options: options
+                   )
       end
 
       def sanitize_headers(headers)

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   module App
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
This makes v2.1 requests work with the OLD class based instance of the code. 

I doubt tests will pass for this, this is branched off very old code. Just need to tag this one and get it on RubyGems.