### PR TITLE
Whiplash App - update version + dependencies

### DIFF
--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end

--- a/whiplash-app.gemspec
+++ b/whiplash-app.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oauth2", "~> 1.2.0"
-  spec.add_dependency "faraday_middleware", "~> 0.11.0"
+  spec.add_dependency "oauth2", "~> 2.0.4"
+  spec.add_dependency "faraday_middleware", "~> 1.2.0"
   spec.add_dependency "moneta", "~> 0.8.0"
 
   spec.add_development_dependency "bundler", ">= 2.2"


### PR DESCRIPTION
update oauth and faraday to rails6 compliant versions. minor version bump.