### PR TITLE
Bad Header String

### DIFF
--- a/lib/whiplash/app.rb
+++ b/lib/whiplash/app.rb
@@ -78,3 +78,24 @@ module Whiplash
 
   end
 end
+
+module Net
+  class HTTPResponse
+    class << self
+      private
+
+      def read_status_line(sock)
+        str = sock.readline
+        og = str.dup
+        str.gsub!(/.*?(?=HTTP)/im, "")
+        if og.size > str.size
+          Rails.logger.warn "[WhiplashApp] Failed to read header status for #{og.inspect}"
+        end
+        m = /\AHTTP(?:\/(\d+\.\d+))?\s+(\d\d\d)(?:\s+(.*))?\z/in.match(str) or
+          raise Net::HTTPBadResponse, "wrong status line: #{str.dump}"
+        m.captures
+      end
+
+    end
+  end
+end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.0"
+    VERSION = "0.9.1"
   end
 end


### PR DESCRIPTION
we're sending some bad characters at the front of an HTTP status header; now strip them and log it