### PR TITLE
Support distinct core url for auth vs API requets

### DIFF
--- a/lib/whiplash/app/canonical_host.rb
+++ b/lib/whiplash/app/canonical_host.rb
@@ -9,7 +9,8 @@ module Whiplash
       def require_canonical_host!
         canonical_host = ENV.fetch('CANONICAL_HOST', false).in?([true, 'true', 1, '1'])
         return unless canonical_host
-        application_host = URI.parse(Rails.configuration.app_url).host
+        return unless Rails.configuration.respond_to?(:application_url)
+        application_host = URI.parse(Rails.configuration.application_url).host
         return if application_host == request.host
         return unless request.method_symbol == :get # can't redirect PUT, POST, DELETE
     
@@ -17,7 +18,7 @@ module Whiplash
       end
     
       def redirect_to_canonical_host(query_params, status=301)
-        redirect_to "#{Rails.configuration.app_url}#{request.path}#{'?' if query_params.to_query.present?}#{query_params.to_query}", status: status
+        redirect_to "#{Rails.configuration.application_url}#{request.path}#{'?' if query_params.to_query.present?}#{query_params.to_query}", status: status
       end
 
     end

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -20,7 +20,7 @@ module Whiplash
       end
 
       def core_url
-        ENV['WHIPLASH_API_URL']
+        ENV['WHIPLASH_CORE_URL'] || ENV['WHIPLASH_API_URL']
       end
 
       def core_url_for(path)

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -5,14 +5,12 @@ module Whiplash
       extend ActiveSupport::Concern
 
       included do
-        if defined?(:helper_method)
-          helper_method :cookie_domain,
-                        :core_url,
-                        :core_url_for,
-                        :current_customer,
-                        :current_user,
-                        :current_warehouse
-        end
+        helper_method :cookie_domain,
+                      :core_url,
+                      :core_url_for,
+                      :current_customer,
+                      :current_user,
+                      :current_warehouse
       end 
 
       private

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -16,7 +16,9 @@ module Whiplash
       private
 
       def cookie_domain
-        '.' + URI.parse(core_url).host
+        host = URI.parse(core_url).host
+        host.gsub!('www.', '')
+        '.' + host
       end
 
       def core_url

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -5,12 +5,14 @@ module Whiplash
       extend ActiveSupport::Concern
 
       included do
-        helper_method :cookie_domain,
-                      :core_url,
-                      :core_url_for,
-                      :current_customer,
-                      :current_user,
-                      :current_warehouse
+        if defined?(:helper_method)
+          helper_method :cookie_domain,
+                        :core_url,
+                        :core_url_for,
+                        :current_customer,
+                        :current_user,
+                        :current_warehouse
+        end
       end 
 
       private

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -26,6 +26,7 @@ module Whiplash
       def core_url_for(path, query_params = {})
         out = [core_url, path].join('/')
         out = [out, query_params.to_query].join('?') if query_params.present?
+        return out
       end
 
       def current_customer

--- a/lib/whiplash/app/controller_helpers.rb
+++ b/lib/whiplash/app/controller_helpers.rb
@@ -23,8 +23,9 @@ module Whiplash
         ENV['WHIPLASH_CORE_URL'] || ENV['WHIPLASH_API_URL']
       end
 
-      def core_url_for(path)
-        [core_url, path].join('/')
+      def core_url_for(path, query_params = {})
+        out = [core_url, path].join('/')
+        out = [out, query_params.to_query].join('?') if query_params.present?
       end
 
       def current_customer
@@ -86,7 +87,7 @@ module Whiplash
       end
 
       def init_whiplash_api(options = {})
-        return redirect_to core_url_for('login') if cookies[:oauth_token].blank?
+        return redirect_to core_url_for('login', redirect_url: request.original_url) if cookies[:oauth_token].blank?
         token = {access_token: cookies[:oauth_token]}
         begin 
           @whiplash_api = Whiplash::App.new(token, options)
@@ -97,7 +98,7 @@ module Whiplash
       end
     
       def require_user
-        redirect_to core_url_for('login') if current_user.blank?
+        redirect_to core_url_for('login', redirect_url: request.original_url) if current_user.blank?
       end
     
       def set_locale!

--- a/lib/whiplash/app/railtie.rb
+++ b/lib/whiplash/app/railtie.rb
@@ -20,7 +20,7 @@ module Whiplash
       end
 
       initializer "whiplash_app.action_controller" do
-        ActiveSupport.on_load(:action_controller) do
+        ActiveSupport.on_load(:action_controller_base) do
           include Whiplash::App::CanonicalHost
           include Whiplash::App::ControllerHelpers
         end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.12"
+    VERSION = "0.9.13"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.8"
+    VERSION = "0.9.9"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.7"
+    VERSION = "0.9.8"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.9"
+    VERSION = "0.9.8"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.6"
+    VERSION = "0.9.7"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.8"
+    VERSION = "0.9.11"
   end
 end

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.11"
+    VERSION = "0.9.12"
   end
 end


### PR DESCRIPTION
Integrations apps all target the Core **Sandbox** API, but each auth in their respective envs (i.e. qa auths against core qa, but hits the core sandbox API).

This allows passing in a second URL, `WHIPLASH_CORE_URL`, to separate the two concerns.