### PR TITLE
Less TCP connection overhead == fewer opportunities for NAT gateway issues

### DIFF
--- a/lib/whiplash/app.rb
+++ b/lib/whiplash/app.rb
@@ -6,6 +6,7 @@ require "whiplash/app/version"
 require "errors/whiplash_api_error"
 require "oauth2"
 require "faraday"
+require 'faraday/net_http_persistent'
 
 # Rails app stuff
 if defined?(Rails::Railtie)

--- a/lib/whiplash/app/version.rb
+++ b/lib/whiplash/app/version.rb
@@ -1,5 +1,5 @@
 module Whiplash
   class App
-    VERSION = "0.9.14"
+    VERSION = "0.10.0"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,7 @@ ENV["WHIPLASH_CLIENT_SCOPE"] = "user_manage"
 ENV["WHIPLASH_API_URL"] = "https://qa.getwhiplash.com/"
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'bundler/setup'
 require 'whiplash/app'
+require 'ostruct'
 require "pry"

--- a/whiplash-app.gemspec
+++ b/whiplash-app.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "oauth2", "~> 2.0.4"
   spec.add_dependency "faraday", "~> 2.7"
+  spec.add_dependency 'net-http-persistent', '~> 4.0'
 
   spec.add_development_dependency "bundler", ">= 2.2"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/whiplash-app.gemspec
+++ b/whiplash-app.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "oauth2", "~> 2.0.4"
   spec.add_dependency "faraday", "~> 2.7"
-  spec.add_dependency 'net-http-persistent', '~> 4.0'
+  spec.add_dependency 'faraday-net_http_persistent'
 
   spec.add_development_dependency "bundler", ">= 2.2"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry" , '~> 0.12.2'
+  spec.add_development_dependency "pry", "~> 0.14"
 end


### PR DESCRIPTION
Using this gem we seem to experience around ~1/10,000 connection failures when hitting whiplash API. Our apps are well designed and retry effectively etc, but:
1) super annoying and fills logs and infra with retries
2) worry problem could get worse under extreme load

Root:
**Net::HTTP** library tends to open a new TCP connection to the server and then close it after the request is complete. 
**net_http_persistent**: Keeps TCP connections alive after a request is finished. When a new request is made to the same host and port, it can reuse the existing open connection. This avoids the overhead of the TCP handshake for subsequent requests.

Added net-http-persistent dependency
Updated Faraday connection to use persistent adapter with optimized timeouts
fallback if dependency unavailable

Bumped minor version (not patch).

[AB#48731](https://dev.azure.com/Ryder-Whiplash/27bb736d-a1c7-46fa-9024-614e5e3ed86e/_workitems/edit/48731)